### PR TITLE
Remove IR from final output

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -76,7 +76,7 @@ impl Lexer {
                 let string = string
                     .strip_prefix('"')
                     .and_then(|string| string.strip_suffix('"'))
-                    .unwrap_or_else(|| string.as_str())
+                    .unwrap_or(string.as_str())
                     .to_owned();
                 return Ok(Lexeme::Literal(Literal::String(StringLiteral::new(
                     string,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -76,7 +76,7 @@ impl Lexer {
                 let string = string
                     .strip_prefix('"')
                     .and_then(|string| string.strip_suffix('"'))
-                    .unwrap_or(string.as_str())
+                    .unwrap_or_else(|| string.as_str())
                     .to_owned();
                 return Ok(Lexeme::Literal(Literal::String(StringLiteral::new(
                     string,

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -106,6 +106,7 @@ fn main_inner() -> Result<(), compiler_solidity::Error> {
                         contract.factory_dependencies =
                             Some(contract_data.factory_dependencies.clone());
                         contract.hash = contract_data.hash.clone();
+                        contract.ir_optimized = None;
                     }
                 }
             }


### PR DESCRIPTION
This reduces the size of standard json output (and therefore the time to pipe the output to stdout / plugins)